### PR TITLE
chore: skip undefined reference warnings in EventStream

### DIFF
--- a/providers/openfeature-provider-flagd/mix.exs
+++ b/providers/openfeature-provider-flagd/mix.exs
@@ -47,7 +47,8 @@ defmodule FlagdProvider.MixProject do
   defp docs do
     [
       main: "readme",
-      extras: ["README.md", "../../LICENSE", "../../CONTRIBUTING.md", "CHANGELOG.md"]
+      extras: ["README.md", "../../LICENSE", "../../CONTRIBUTING.md", "CHANGELOG.md"],
+      skip_undefined_reference_warnings_on: ["OpenFeature.Provider.Flagd.GRPC.EventStream"]
     ]
   end
 


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Skips warnings of undefined references to the `OpenFeature.EventEmitter` SDK module in `OpenFeature.Provider.Flagd.GRPC.EventStream`

### How to test

`MIX_ENV=docs mix docs` generates 0 warnings